### PR TITLE
Add content viewset

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .content_tests import ContentTests

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -4,39 +4,52 @@ from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 
+    
 class ContentTests(APITestCase):
-    fixtures = ["field_type.json", "content.json", "tokens.json", "users.json", "whoyou_user.json"]
-
-
+    fixtures = ["field_type.json"]    
+    
+    
     def setUp(self):
         """
-        Create a new account, which will also create sample categories
+        Create two new accounts, which will be used to verify that the right level of content is exposed
         """
-        # create field types
+        def createUser(userData):
+            url = "/register"
+            
+            response = self.client.post(url, userData, format='json')
+            json_response = json.loads(response.content)
 
-        url = "/register"
-        data = {
+            # Assert that a user was created
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            return json_response
+
+        trinityData = {
             "name": "Trinity",
             "email": "trinity@theResistance.com",
             "password": "trinity",
             "phone": "1234567890"
         }
-        response = self.client.post(url, data, format='json')
-        json_response = json.loads(response.content)
+        agentSmithData = {
+            "name": "Agent Smith",
+            "email": "smith@test.com",
+            "password": "smith",
+            "phone": "1234567890"
+        }
+        trinityResponse = createUser(trinityData)
+        self.trinityId = trinityResponse["id"]
+        self.trinityToken = trinityResponse["token"]
 
-        # Store the auth token and user id for later use
-        self.token = json_response["token"]
-        self.newUserId = json_response['id']
-
-        # Assert that a user was created
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
+        smithResponse = createUser(agentSmithData)
+        self.agentSmithId = smithResponse["id"]
+        self.agentSmithToken = smithResponse["token"]
+        
 
     def test_request_content_as_unauthenticated(self):
         """
         Verify that the correct values are returned when an un-authenticated user requests a user's content
         """
-        url = f"/content?owner={self.newUserId}"
+        url = f"/content?owner={self.trinityId}"
         response = self.client.get(url, format='json')
         json_response = json.loads(response.content)
 
@@ -49,15 +62,16 @@ class ContentTests(APITestCase):
             if content["field_type"]["name"] == "email":
                 self.assertEqual(content["value"], "restricted value")
     
+
     def test_request_content_as_self(self):
         """
         Verify that the correct values are returned when user requests their own content
         """
         # Make sure request is authenticated
         client = APIClient()
-        client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.trinityToken)
         
-        url = f"/content?owner={self.newUserId}"
+        url = f"/content?owner={self.trinityId}"
         response = client.get(url, format='json')
         json_response = json.loads(response.content)
 
@@ -69,5 +83,27 @@ class ContentTests(APITestCase):
                 self.assertEqual(content["value"], "1234567890")
             if content["field_type"]["name"] == "email":
                 self.assertEqual(content["value"], "trinity@theResistance.com")
+
+
+    def test_request_content_as_other(self):
+        """
+        Verify that the correct values are returned when user requests their own content
+        """
+        # Make sure request is authenticated
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        
+        url = f"/content?owner={self.trinityId}"
+        response = client.get(url, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for content in json_response:
+            if content["field_type"]["name"] == "name":
+                self.assertEqual(content["value"], "Trinity")
+            if content["field_type"]["name"] == "phone":
+                self.assertEqual(content["value"], "restricted value")
+            if content["field_type"]["name"] == "email":
+                self.assertEqual(content["value"], "restricted value")
         
 

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -1,0 +1,58 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class ContentTests(APITestCase):
+    fixtures = ["field_type.json", "content.json", "tokens.json", "users.json", "whoyou_user.json"]
+
+    def setUp(self):
+        """
+        Create a new account and create sample category
+        """
+        # create field types
+
+        url = "/register"
+        data = {
+            "name": "Trinity",
+            "email": "trinity@theResistance.com",
+            "password": "trinity",
+            "phone": "1234567890"
+        }
+        # Initiate request and capture response
+        response = self.client.post(url, data, format='json')
+
+        # Parse the JSON in the response body
+        json_response = json.loads(response.content)
+
+        # Store the auth token
+        self.token = json_response["token"]
+        self.newUserId =json_response['id']
+
+        # Assert that a user was created
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+    def test_request_content(self):
+        """
+        Verify that the correct values are returned when a user requests another user's content
+        """
+
+        # Authenticate as Agent Smith from the fixtures
+        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        url = f"/content?user={self.newUserId}"
+        # Initiate request and store response
+        response = self.client.get(url, format='json')
+
+        # Parse the JSON in the response body
+        json_response = json.loads(response.content)
+
+        # Assert that the response code is correct
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Assert that the properties on the created resource are correct
+        self.assertEqual(json_response[0]["value"], "Trinity")
+        # self.assertEqual(json_response["maker"], "Milton Bradley")
+        # self.assertEqual(json_response["skill_level"], 5)
+        # self.assertEqual(json_response["number_of_players"], 6)

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -107,3 +107,7 @@ class ContentTests(APITestCase):
                 self.assertEqual(content["value"], "restricted value")
         
 
+# TODO Add tests for retrieving a specific piece of content by id
+# TODO Add tests for creating content (This should only be allowed by authenticated users)
+# TODO Add tests for updating content (This should only be allowed by the content owner)
+# TODO Add tests for deleting content (This should only be allowed by the content owner)

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -1,6 +1,7 @@
 import json
+from whoYouApi.models import field_type
 from rest_framework import status
-from rest_framework.test import APITestCase
+from rest_framework.test import APIClient, APITestCase
 
 
 class ContentTests(APITestCase):
@@ -41,13 +42,32 @@ class ContentTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         for content in json_response:
-            if content.field_type.value == "name":
+            if content["field_type"]["name"] == "name":
                 self.assertEqual(content["value"], "Trinity")
-            if content.field_type.value == "phone":
+            if content["field_type"]["name"] == "phone":
                 self.assertEqual(content["value"], "restricted value")
-            if content.field_type.value == "email":
+            if content["field_type"]["name"] == "email":
                 self.assertEqual(content["value"], "restricted value")
     
+    def test_request_content_as_self(self):
+        """
+        Verify that the correct values are returned when user requests their own content
+        """
+        # Make sure request is authenticated
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        
+        url = f"/content?owner={self.newUserId}"
+        response = client.get(url, format='json')
+        json_response = json.loads(response.content)
 
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for content in json_response:
+            if content["field_type"]["name"] == "name":
+                self.assertEqual(content["value"], "Trinity")
+            if content["field_type"]["name"] == "phone":
+                self.assertEqual(content["value"], "1234567890")
+            if content["field_type"]["name"] == "email":
+                self.assertEqual(content["value"], "trinity@theResistance.com")
         
 

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -6,9 +6,10 @@ from rest_framework.test import APITestCase
 class ContentTests(APITestCase):
     fixtures = ["field_type.json", "content.json", "tokens.json", "users.json", "whoyou_user.json"]
 
+
     def setUp(self):
         """
-        Create a new account and create sample category
+        Create a new account, which will also create sample categories
         """
         # create field types
 
@@ -19,40 +20,34 @@ class ContentTests(APITestCase):
             "password": "trinity",
             "phone": "1234567890"
         }
-        # Initiate request and capture response
         response = self.client.post(url, data, format='json')
-
-        # Parse the JSON in the response body
         json_response = json.loads(response.content)
 
-        # Store the auth token
+        # Store the auth token and user id for later use
         self.token = json_response["token"]
-        self.newUserId =json_response['id']
+        self.newUserId = json_response['id']
 
         # Assert that a user was created
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
-    def test_request_content(self):
+    def test_request_content_as_unauthenticated(self):
         """
-        Verify that the correct values are returned when a user requests another user's content
+        Verify that the correct values are returned when an un-authenticated user requests a user's content
         """
-
-        # Authenticate as Agent Smith from the fixtures
-        # self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-
-        url = f"/content?user={self.newUserId}"
-        # Initiate request and store response
+        url = f"/content?owner={self.newUserId}"
         response = self.client.get(url, format='json')
-
-        # Parse the JSON in the response body
         json_response = json.loads(response.content)
 
-        # Assert that the response code is correct
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for content in json_response:
+            if content.field_type.value == "name":
+                self.assertEqual(content["value"], "Trinity")
+            if content.field_type.value == "phone":
+                self.assertEqual(content["value"], "restricted value")
+            if content.field_type.value == "email":
+                self.assertEqual(content["value"], "restricted value")
+    
 
-        # Assert that the properties on the created resource are correct
-        self.assertEqual(json_response[0]["value"], "Trinity")
-        # self.assertEqual(json_response["maker"], "Milton Bradley")
-        # self.assertEqual(json_response["skill_level"], 5)
-        # self.assertEqual(json_response["number_of_players"], 6)
+        
+

--- a/whoYouApi/fixtures/content.json
+++ b/whoYouApi/fixtures/content.json
@@ -1,0 +1,68 @@
+[
+    {
+        "model": "whoYouApi.Content",
+        "pk": 1,
+        "fields": {
+            "field_type": 3,
+            "value": "Neo",
+            "owner": 1,
+            "is_public": true,
+            "verification_time": "2020-12-14T23:18:18.028751Z"
+        }
+    },
+    {
+        "model": "whoYouApi.Content",
+        "pk": 2,
+        "fields": {
+            "field_type": 1,
+            "value": "1234567890",
+            "owner": 1,
+            "is_public": false,
+            "verification_time": "2020-12-14T23:18:18.032244Z"
+        }
+    },
+    {
+        "model": "whoYouApi.Content",
+        "pk": 3,
+        "fields": {
+            "field_type": 2,
+            "value": "neo@theResistance.com",
+            "owner": 1,
+            "is_public": false,
+            "verification_time": "2020-12-14T23:18:18.034957Z"
+        }
+    },
+    {
+        "model": "whoYouApi.Content",
+        "pk": 4,
+        "fields": {
+            "field_type": 3,
+            "value": "Agent Smith",
+            "owner": 2,
+            "is_public": true,
+            "verification_time": "2020-12-14T23:18:18.028751Z"
+        }
+    },
+    {
+        "model": "whoYouApi.Content",
+        "pk": 5,
+        "fields": {
+            "field_type": 1,
+            "value": "1234567890",
+            "owner": 2,
+            "is_public": false,
+            "verification_time": "2020-12-14T23:18:18.032244Z"
+        }
+    },
+    {
+        "model": "whoYouApi.Content",
+        "pk": 6,
+        "fields": {
+            "field_type": 2,
+            "value": "smith@theMatrix.com",
+            "owner": 2,
+            "is_public": false,
+            "verification_time": "2020-12-14T23:18:18.034957Z"
+        }
+    }
+]

--- a/whoYouApi/fixtures/tokens.json
+++ b/whoYouApi/fixtures/tokens.json
@@ -1,0 +1,19 @@
+[
+    {
+        "model": "authtoken.token",
+        "pk": "fa2eba9be8282d595c997ee5cd49f2ed31f65bed",
+        "fields": {
+            "user": 1,
+            "created": "2020-08-29T13:24:27.172Z"
+        }
+    },
+    {
+      "model": "authtoken.token",
+      "pk": "7f6d2aca4d0d1e7f4e606c36b592f7736000ee92",
+      "fields": {
+          "user": 2,
+          "created": "2020-08-29T13:24:27.172Z"
+        }
+    }
+  
+]

--- a/whoYouApi/fixtures/users.json
+++ b/whoYouApi/fixtures/users.json
@@ -1,0 +1,38 @@
+[
+    {
+        "model": "auth.user",
+        "pk": 1,
+        "fields": {
+            "password": "pbkdf2_sha256$216000$7a4WvJJj9lpO$IVuCKlGzsBHv2wFxuGmYj5MCpRiGFwx26eizhaQD6I0=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "neo@theResistance.com",
+            "first_name": "",
+            "last_name": "",
+            "email": "neo@theResistance.com",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2020-08-28T14:51:39.989Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "auth.user",
+        "pk": 2,
+        "fields": {
+            "password": "pbkdf2_sha256$216000$EwmiIhVV0f0a$JUAX9c5Vv64yhKbJ0UQ97Sq17zYlh8X+FEYmaGDCoq4=",
+            "last_login": null,
+            "is_superuser": false,
+            "username": "smith@theMatrix.com",
+            "first_name": "",
+            "last_name": "",
+            "email": "smith@theMatrix.com",
+            "is_staff": true,
+            "is_active": true,
+            "date_joined": "2020-08-28T14:51:39.989Z",
+            "groups": [],
+            "user_permissions": []
+        }
+    }
+]

--- a/whoYouApi/fixtures/whoyou_user.json
+++ b/whoYouApi/fixtures/whoyou_user.json
@@ -1,0 +1,22 @@
+[
+    {
+        "model": "whoYouApi.WhoYouUser",
+        "pk": 1,
+        "fields": {
+            "profile_image_path": "",
+            "cover_image_path": "",
+            "user": 1,
+            "full_name": "Neo"
+        }
+    },
+    {
+        "model": "whoYouApi.WhoYouUser",
+        "pk": 2,
+        "fields": {
+            "profile_image_path": "",
+            "cover_image_path": "",
+            "user": 2,
+            "full_name": "Agent Smith"
+        }
+    }
+]

--- a/whoYouApi/views/__init__.py
+++ b/whoYouApi/views/__init__.py
@@ -1,1 +1,2 @@
 from .auth import login_user, register_user
+from .content import ContentViewSet

--- a/whoYouApi/views/auth.py
+++ b/whoYouApi/views/auth.py
@@ -68,7 +68,7 @@ def register_user(request):
     # Create a new content object containing the user's name
     # This will allow the user to give permissions to view this content to other users
     new_phone = Content.objects.create(
-        field_type = FieldType.objects.get(name="phone"),
+        field_type = FieldType.objects.get(name="name"),
         value = req_body["name"],
         owner = whoyou_user,
         is_public = True,

--- a/whoYouApi/views/auth.py
+++ b/whoYouApi/views/auth.py
@@ -108,5 +108,8 @@ def register_user(request):
 
     # Return the token, to the user so that they can authenticate.
     data = json.dumps(
-        {"token": token.key})
+        {
+            "token": token.key,
+            "id": whoyou_user.id
+        })
     return HttpResponse(data, content_type='application/json')

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -43,17 +43,22 @@ class ContentViewSet(ViewSet):
         if user_id is not None:
             content_objects = content_objects.filter(owner=user_id)
         
-        serializer  = ContentSerializer(
+        serializer  = PublicContentSerializer(
             content_objects, many=True, context={'request': request}
         )
         return Response(serializer.data)
         
 
-
-class ContentSerializer(serializers.ModelSerializer):
-    """Serializer for Content"""
-    # TODO: dynamically assign fields based on who is asking for the data, whether the data is public, and whether the user has permissions to view the data
+class PublicContentSerializer(serializers.ModelSerializer):
+    """Serializer for public Content"""
     class Meta:
         model = Content
-        fields = ( 'field_type', 'value', 'owner', 'is_public', 'verification_time')
+        fields = ( 'id', 'field_type', 'owner', 'is_public', 'verification_time')
         depth = 1
+class RestrictedContentSerializer(serializers.ModelSerializer):
+    """Serializer for public Content"""
+    class Meta:
+        model = Content
+        fields = ( 'id', 'field_type', 'value', 'owner', 'is_public', 'verification_time')
+        depth = 1
+

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -43,22 +43,26 @@ class ContentViewSet(ViewSet):
         if user_id is not None:
             content_objects = content_objects.filter(owner=user_id)
         
-        serializer  = PublicContentSerializer(
+        serializer  = =ContentSerializer(
             content_objects, many=True, context={'request': request}
         )
         return Response(serializer.data)
         
 
-class PublicContentSerializer(serializers.ModelSerializer):
-    """Serializer for public Content"""
-    class Meta:
+class ContentSerializer(serializers.ModelSerializer):
+    """Serializer for Content"""
+        # TODO: dynamically assign fields based on who is asking for the data, 
+        # whether the data is public, and whether the user has permissions to view the data
+        # def validateValuePermissions():
+            # If the content object is public:
+            # content_object.is_public
+            # OR the requester is the owner
+            # WhoYouUser.objects.get(user=request.auth.user) == content_object.owner
+            # OR the requester has a valid view request for this content
+            # TBD
+            # Then return the full content
+            # ELSE exclude the value from the response    class Meta:
         model = Content
-        fields = ( 'id', 'field_type', 'owner', 'is_public', 'verification_time')
-        depth = 1
-class RestrictedContentSerializer(serializers.ModelSerializer):
-    """Serializer for public Content"""
-    class Meta:
-        model = Content
-        fields = ( 'id', 'field_type', 'value', 'owner', 'is_public', 'verification_time')
+        fields = ( 'id', 'field_type','value', 'owner', 'is_public', 'verification_time')
         depth = 1
 

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -47,7 +47,11 @@ class ContentViewSet(ViewSet):
         # Censor out values that the user shouldn't be able to access
         censored_content_objects = []
         for content_object in content_objects:
-            censored_content = censorContent(content_object, request.auth.user)
+            try: 
+                requester = WhoYouUser.objects.get(user=request.auth.user)
+            except AttributeError:
+                requester = None
+            censored_content = censorContent(content_object, requester)
             censored_content_objects.append(censored_content)
 
         serializer = ContentSerializer(
@@ -114,7 +118,7 @@ class ContentViewSet(ViewSet):
     
 
 def censorContent(content_object, requestingUser):
-    isRequesterContentOwner = WhoYouUser.objects.get(user=requestingUser) == content_object.owner
+    isRequesterContentOwner = requestingUser == content_object.owner
     if content_object.is_public or isRequesterContentOwner:
     #TODO: check if the requester has a valid view request for this content
         return content_object

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -6,6 +6,7 @@ from whoYouApi.models import WhoYouUser, Content
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
+from rest_framework import status
 
 
 class ContentViewSet(ViewSet):
@@ -46,20 +47,61 @@ class ContentViewSet(ViewSet):
         # Censor out values that the user shouldn't be able to access
         censored_content_objects = []
         for content_object in content_objects:
-            isRequesterContentOwner = WhoYouUser.objects.get(user=request.auth.user) == content_object.owner
-            if content_object.is_public or isRequesterContentOwner:
-                censored_content_objects.append(content_object)
-            #TODO: check if the requester has a valid view request for this content
-            else:
-                content_object.value = "restricted value"
-                censored_content_objects.append(content_object)
+            censored_content = censorContent(content_object, request.auth.user)
+            censored_content_objects.append(censored_content)
 
         serializer = ContentSerializer(
-            content_objects, many=True, context={'request': request}
+            censored_content_objects, many=True, context={'request': request}
         )
         return Response(serializer.data)
 
 
+    def retrieve(self, request, pk=None):
+        """Handle GET request for single content instance
+        Returns:
+            Response JSON serialized content instance
+        """
+        content = Content.objects.get(pk=pk)
+        censoredContent = censorContent(content, request.auth.user)
+        serializer = ContentSerializer(content, context={'request': request})
+        return Response(serializer.data)
+        
+    def update(self, request, pk=None):
+        """ Handle an PUT request for content
+        Returns:
+            Response code
+        """
+
+        # Find the post being updated based on it's primary key
+        content = Content.objects.get(pk=pk)
+
+        #Prevent non-admin users from modifying other user's posts
+        requester = WhoYouUser.objects.get(user=request.auth.user)
+        if requester != content.owner:
+            return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        # save basic (non-associated) properties
+        content.owner = requester
+        field_type = FieldType.objects.get(pk=request.data["field_type"])
+        content.field_type = field_type
+        content.value = request.data["value"]
+        content.is_public = request.data["is_public"] == "true"
+        content.verification_time = timezone.now()
+
+        # save content object
+        content.save()
+
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+
+def censorContent(content_object, requestingUser):
+    isRequesterContentOwner = WhoYouUser.objects.get(user=requestingUser) == content_object.owner
+    if content_object.is_public or isRequesterContentOwner:
+    #TODO: check if the requester has a valid view request for this content
+        return content_object
+    else:
+        content_object.value = "restricted value"
+        return content_object
 
 class ContentSerializer(serializers.ModelSerializer):
     """Serializer for Content"""     

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -43,26 +43,27 @@ class ContentViewSet(ViewSet):
         if user_id is not None:
             content_objects = content_objects.filter(owner=user_id)
         
-        serializer  = =ContentSerializer(
+        # Censor out values that the user shouldn't be able to access
+        censored_content_objects = []
+        for content_object in content_objects:
+            isRequesterContentOwner = WhoYouUser.objects.get(user=request.auth.user) == content_object.owner
+            if content_object.is_public or isRequesterContentOwner:
+                censored_content_objects.append(content_object)
+            #TODO: check if the requester has a valid view request for this content
+            else:
+                content_object.value = "restricted value"
+                censored_content_objects.append(content_object)
+
+        serializer = ContentSerializer(
             content_objects, many=True, context={'request': request}
         )
         return Response(serializer.data)
-        
+
+
 
 class ContentSerializer(serializers.ModelSerializer):
-    """Serializer for Content"""
-        # TODO: dynamically assign fields based on who is asking for the data, 
-        # whether the data is public, and whether the user has permissions to view the data
-        # def validateValuePermissions():
-            # If the content object is public:
-            # content_object.is_public
-            # OR the requester is the owner
-            # WhoYouUser.objects.get(user=request.auth.user) == content_object.owner
-            # OR the requester has a valid view request for this content
-            # TBD
-            # Then return the full content
-            # ELSE exclude the value from the response    class Meta:
+    """Serializer for Content"""     
+    class Meta:
         model = Content
         fields = ( 'id', 'field_type','value', 'owner', 'is_public', 'verification_time')
         depth = 1
-

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -1,0 +1,24 @@
+""" View module for handling requests about content"""
+from whoYouApi.models.field_type import FieldType
+from rest_framework.viewsets import ViewSet
+from whoYouApi.models import WhoYouUser, Content
+from django.utils import timezone
+
+class ContentViewSet(ViewSet):
+    """ WhoYou Content """
+
+    def create(self, request):
+        """Handle POST operations
+        Returns:
+            Response -- JSON serialized post instance
+        """
+        content_owner = WhoYouUser.objects.get(user=request.auth.user)
+        content = Content()
+        content.owner = content_owner
+    
+        field_type = FieldType.objects.get(pk=request.data["field_type"])
+        content.field_type = field_type
+        content.value = request.data["value"]
+        content.is_public = request.data["is_public"] == "true"
+        content.verification_time = timezone.now()
+

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -63,7 +63,7 @@ class ContentViewSet(ViewSet):
         """
         content = Content.objects.get(pk=pk)
         censoredContent = censorContent(content, request.auth.user)
-        serializer = ContentSerializer(content, context={'request': request})
+        serializer = ContentSerializer(censoredContent, context={'request': request})
         return Response(serializer.data)
         
     def update(self, request, pk=None):

--- a/whoYouServer/settings.py
+++ b/whoYouServer/settings.py
@@ -47,7 +47,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rest_framework.permissions.AllowAny',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 10

--- a/whoYouServer/urls.py
+++ b/whoYouServer/urls.py
@@ -1,11 +1,12 @@
 from django.conf.urls import include
 from django.urls import path
 from rest_framework import routers
-from whoYouApi.views import register_user, login_user
+from whoYouApi.views import register_user, login_user, ContentViewSet
 
 
 """Router"""
 router = routers.DefaultRouter(trailing_slash=False)
+router.register(r'content', ContentViewSet, 'content')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
# Description
Add a content viewset so that users can create and get content. The key feature is that if a user who doesn't have permission to access a piece of content requests that content, the value will be redacted.

- Added fixtures for sample data
- Added content view set
- Added tests module to verify that private content isn't sent to unauthorized users

Side effects
- Changed the auth model to also return the user Id when a user is authenticated. This allows the user to know where to make requests for their own data
- ⚠️⚠️⚠️⚠️Changed the DEFAULT PERMISSION CLASS to ALLOW ANY. This is a big deal! ⚠️⚠️⚠️⚠️⚠️ If it were not so early in the project I would make this a separate PR. The point of this change is to allow unauthenticated users to make requests to the app. Sign-ins should only be required for creating requests.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Run the test suite: `python manage.py test tests -v 1`
- [ ] Verify that the test suite has sufficient tests for listing user content
- [ ] In postman, verify that a user can create, update and delete their own content
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings