### PR TITLE
Add content view requests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from .content_tests import ContentTests
+from .contentViewRequest_tests import ContentViewRequestTests

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -93,9 +93,9 @@ class ContentViewRequestTests(APITestCase):
         self.assertEqual(json_response["reason"], "Request already exists")
 
 
-    def test_get_content_request_by_userId(self): 
+    def test_get_content_requests(self): 
         """
-        Verify that the correct values are returned when user requests their access to another user's content
+        Verify that the correct values are returned when user gets content requests
         """
         client = APIClient()
 
@@ -111,10 +111,26 @@ class ContentViewRequestTests(APITestCase):
         # Change authentication to trinity 
         client.credentials(HTTP_AUTHORIZATION='Token ' + self.trinityToken)
 
-        # Create the first request to view content
+        # Get Trinity's content requests
         response = client.get(url, format='json')
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        is_smith_content_request_in_response = any( elm["content"]["id"] == 2 for elm in json_response)
+        self.assertEqual(is_smith_content_request_in_response, True)
         self.assertEqual(len(json_response), 1)
 
-        
+        # Post a request to view another user's content as trinity
+        data = {
+           "content": 6
+        }
+        url = "/contentViewRequest"
+        response = client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Get content view requests as trinity again
+        response = client.get(url, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        is_trinity_content_request_in_response = any( elm["content"]["id"] == 6 for elm in json_response)
+        self.assertEqual(is_trinity_content_request_in_response, True)
+        self.assertEqual(len(json_response), 2)

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -129,9 +129,10 @@ class ContentViewRequestTests(APITestCase):
         self.assertEqual(is_trinity_content_request_in_response, True)
         self.assertEqual(len(json_response), 2)
     
-    def test_approve_own_content_request_expect_error(self):
+    def test_approve_own_request_expect_error(self):
         """
-        Only content owners should be able to approve a content request
+        Test that a user can NOT approve a content view request for content that 
+        they do NOT own
         """
         client = APIClient()
         url = F"/contentViewRequest/{self.agentSmithRequestForTrinityInfo}"
@@ -140,8 +141,24 @@ class ContentViewRequestTests(APITestCase):
         data = {
            "is_approved": True
         }
-        response = client.patch(url, format='json')
+        response = client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+    
+    
+    def test_approve_request_for_own_content_expect_success(self):
+        """
+        Test that a user CAN approve a content view request for content that 
+        they DO own
+        """
+        client = APIClient()
+        url = F"/contentViewRequest/{self.agentSmithRequestForTrinityInfo}"
+        # Get Trinity's content requests
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.trinityToken)
+        data = {
+           "is_approved": True
+        }
+        response = client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
 
 
@@ -149,9 +166,6 @@ class ContentViewRequestTests(APITestCase):
         # Users should only be able to get requests that they created, 
         # or that are addressed to their content
 
-        # TODO: Add tests for updating a content view request. 
-        # Users should only be able to update requests to 
-        # content that they own
 
         # TODO: Add tests for deleting a content view request.
         # Users should only be able to delete a content view request

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -48,6 +48,8 @@ class ContentViewRequestTests(APITestCase):
         }
         url = "/contentViewRequest"
         response = client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.agentSmithRequestForTrinityInfo = json_response["id"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Change authentication to trinity 
@@ -57,6 +59,8 @@ class ContentViewRequestTests(APITestCase):
            "content": 6
         }
         response = client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.trinityRequestForSmithInfo = json_response["id"]
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_view_request_for_content_no_value_returned(self):
@@ -124,6 +128,22 @@ class ContentViewRequestTests(APITestCase):
         self.assertEqual(is_smith_content_request_in_response, True)
         self.assertEqual(is_trinity_content_request_in_response, True)
         self.assertEqual(len(json_response), 2)
+    
+    def test_approve_own_content_request_expect_error(self):
+        """
+        Only content owners should be able to approve a content request
+        """
+        client = APIClient()
+        url = F"/contentViewRequest/{self.agentSmithRequestForTrinityInfo}"
+        # Get Trinity's content requests
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        data = {
+           "is_approved": True
+        }
+        response = client.patch(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
 
         # TODO: Add tests for getting single content view request. 
         # Users should only be able to get requests that they created, 

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -138,3 +138,11 @@ class ContentViewRequestTests(APITestCase):
         # TODO: Add tests for getting single content view request. 
         # Users should only be able to get requests that they created, 
         # or that are addressed to their content
+
+        # TODO: Add tests for updating a content view request. 
+        # Users should only be able to update requests to 
+        # content that they own
+
+        # TODO: Add tests for deleting a content view request.
+        # Users should only be able to delete a content view request
+        # that they created

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -134,3 +134,7 @@ class ContentViewRequestTests(APITestCase):
         is_trinity_content_request_in_response = any( elm["content"]["id"] == 6 for elm in json_response)
         self.assertEqual(is_trinity_content_request_in_response, True)
         self.assertEqual(len(json_response), 2)
+
+        # TODO: Add tests for getting single content view request. 
+        # Users should only be able to get requests that they created, 
+        # or that are addressed to their content

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -1,0 +1,72 @@
+import json
+from whoYouApi.models import field_type
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+
+    
+class ContentViewRequestTests(APITestCase):
+    fixtures = ["field_type.json"]    
+    
+    
+    def setUp(self):
+        """
+        Create two new accounts, which will be used to verify that the right level of content is exposed
+        """
+        def createUser(userData):
+            url = "/register"
+            
+            response = self.client.post(url, userData, format='json')
+            json_response = json.loads(response.content)
+
+            # Assert that a user was created
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            return json_response
+
+        trinityData = {
+            "name": "Trinity",
+            "email": "trinity@theResistance.com",
+            "password": "trinity",
+            "phone": "1234567890"
+        }
+        agentSmithData = {
+            "name": "Agent Smith",
+            "email": "smith@test.com",
+            "password": "smith",
+            "phone": "1234567890"
+        }
+        trinityResponse = createUser(trinityData)
+        self.trinityId = trinityResponse["id"]
+        self.trinityToken = trinityResponse["token"]
+
+        smithResponse = createUser(agentSmithData)
+        self.agentSmithId = smithResponse["id"]
+        self.agentSmithToken = smithResponse["token"]
+        
+
+    def test_view_request_for_content_no_value_returned(self):
+        """
+        Verify that the correct values are returned when user requests their own content
+        """
+        # Make sure request is authenticated
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        
+        data = {
+            "content": 2
+        }
+        url = "/contentViewRequest"
+        response = client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["is_approved"], False)
+
+        # Make sure that the value from the content was NOT returned with the contentViewRequest
+        if "value" in json_response['content']:
+            isValueInContent = True
+        else:
+            isValueInContent = False    
+        self.assertEqual(isValueInContent, False)
+        

--- a/tests/contentViewRequest_tests.py
+++ b/tests/contentViewRequest_tests.py
@@ -91,3 +91,30 @@ class ContentViewRequestTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         self.assertEqual(json_response["reason"], "Request already exists")
+
+
+    def test_get_content_request_by_userId(self): 
+        """
+        Verify that the correct values are returned when user requests their access to another user's content
+        """
+        client = APIClient()
+
+        # Create a content View Request as Agent Smith
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        data = {
+           "content": 2
+        }
+        url = "/contentViewRequest"
+        response = client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Change authentication to trinity 
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.trinityToken)
+
+        # Create the first request to view content
+        response = client.get(url, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
+
+        

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -47,7 +47,7 @@ class ContentTests(APITestCase):
 
     def test_request_content_as_unauthenticated(self):
         """
-        Verify that the correct values are returned when an un-authenticated user requests a user's content
+        Verify that the correct values are returned when an un-authenticated user GETs a user's content
         """
         url = f"/content?owner={self.trinityId}"
         response = self.client.get(url, format='json')
@@ -65,7 +65,7 @@ class ContentTests(APITestCase):
 
     def test_request_content_as_self(self):
         """
-        Verify that the correct values are returned when user requests their own content
+        Verify that the correct values are returned when user GETs their own content
         """
         # Make sure request is authenticated
         client = APIClient()
@@ -87,7 +87,7 @@ class ContentTests(APITestCase):
 
     def test_request_content_as_other(self):
         """
-        Verify that the correct values are returned when user requests their own content
+        Verify that the correct values are returned when user GETs another user's content
         """
         # Make sure request is authenticated
         client = APIClient()

--- a/whoYouApi/views/__init__.py
+++ b/whoYouApi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import login_user, register_user
 from .content import ContentViewSet
+from .content_view_request import ContentViewRequestViewSet

--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -76,15 +76,12 @@ class ContentViewSet(ViewSet):
             Response code
         """
 
-        # Find the post being updated based on it's primary key
         content = Content.objects.get(pk=pk)
 
-        #Prevent non-admin users from modifying other user's posts
         requester = WhoYouUser.objects.get(user=request.auth.user)
         if requester != content.owner:
             return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
 
-        # save basic (non-associated) properties
         content.owner = requester
         field_type = FieldType.objects.get(pk=request.data["field_type"])
         content.field_type = field_type
@@ -92,7 +89,6 @@ class ContentViewSet(ViewSet):
         content.is_public = request.data["is_public"] == "true"
         content.verification_time = timezone.now()
 
-        # save content object
         content.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
@@ -105,7 +101,6 @@ class ContentViewSet(ViewSet):
         try:
             content = Content.objects.get(pk=pk)
 
-            #Prevent non-admin users from deleting posts from other users
             requesting_user = WhoYouUser.objects.get(user=request.auth.user)
             if requesting_user == content.owner:
                 content.delete()

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -17,48 +17,53 @@ class ContentViewRequestViewSet(ViewSet):
         Returns:
             Response -- JSON serialized ContentViewRequest instance
         """
+
         content_view_request = ContentViewRequest()
         requester = WhoYouUser.objects.get(user=request.auth.user)
         content_view_request.requester = requester
         requested_content = request.data["content"]
         content = Content.objects.get(pk=requested_content)
-        content_view_request.content = content
-        content_view_request.is_approved = False
-        content_view_request.creation_time = timezone.now()
+        try:
+            existingRequest = ContentViewRequest.objects.get(content=requested_content, requester=requester)
+            return Response({"reason": "Request already exists"}, status=status.HTTP_400_BAD_REQUEST)
+        except ContentViewRequest.DoesNotExist:
+            content_view_request.content = content
+            content_view_request.is_approved = False
+            content_view_request.creation_time = timezone.now()
 
-        content_view_request.save()
+            content_view_request.save()
 
-        serializer = ContentViewRequestSerializer(content_view_request, context={'request': request})
-        return Response(serializer.data)
+            serializer = ContentViewRequestSerializer(content_view_request, context={'request': request})
+            return Response(serializer.data)
 
-#     def list(self, request):
-#         """Handle GET requests to Content resource
+    # def list(self, request):
+    #     """Handle GET requests to Content resource
 
-#         Returns:
-#             Response -- JSON serialized list of Content
-#         """
-#         content_objects = Content.objects.all()
+    #     Returns:
+    #         Response -- JSON serialized list of Content
+    #     """
+    #     content_objects = Content.objects.all()
 
-#         # Filter content based on query parameters
-#         # e.g.: /content?owner=1
-#         user_id = self.request.query_params.get('owner', None)
-#         if user_id is not None:
-#             content_objects = content_objects.filter(owner=user_id)
+    #     # Filter content based on query parameters
+    #     # e.g.: /content?owner=1
+    #     user_id = self.request.query_params.get('owner', None)
+    #     if user_id is not None:
+    #         content_objects = content_objects.filter(owner=user_id)
         
-#         # Censor out values that the user shouldn't be able to access
-#         censored_content_objects = []
-#         for content_object in content_objects:
-#             try: 
-#                 requester = WhoYouUser.objects.get(user=request.auth.user)
-#             except AttributeError:
-#                 requester = None
-#             censored_content = censorContent(content_object, requester)
-#             censored_content_objects.append(censored_content)
+    #     # Censor out values that the user shouldn't be able to access
+    #     censored_content_objects = []
+    #     for content_object in content_objects:
+    #         try: 
+    #             requester = WhoYouUser.objects.get(user=request.auth.user)
+    #         except AttributeError:
+    #             requester = None
+    #         censored_content = censorContent(content_object, requester)
+    #         censored_content_objects.append(censored_content)
 
-#         serializer = ContentSerializer(
-#             censored_content_objects, many=True, context={'request': request}
-#         )
-#         return Response(serializer.data)
+    #     serializer = ContentSerializer(
+    #         censored_content_objects, many=True, context={'request': request}
+    #     )
+    #     return Response(serializer.data)
 
 
 #     def retrieve(self, request, pk=None):

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -71,11 +71,8 @@ class ContentViewRequestViewSet(ViewSet):
         Returns:
             Response code
         """
-
-        # Find the post being updated based on it's primary key
         contentViewRequest = ContentViewRequest.objects.get(pk=pk)
 
-        #Prevent non-admin users from modifying other user's posts
         requester = WhoYouUser.objects.get(user=request.auth.user)
         if requester != contentViewRequest.content.owner:
             return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
@@ -86,36 +83,25 @@ class ContentViewRequestViewSet(ViewSet):
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)
 
-#     def destroy(self, request, pk=None):
-#         """ Handle an DELETE request for content
-#         Returns:
-#             Response code
-#         """
-#         try:
-#             content = Content.objects.get(pk=pk)
+    def destroy(self, request, pk=None):
+        """ Handle an DELETE request for single contentViewRequest
+        Returns:
+            Response code
+        """
+        try:
+            contentViewRequest = ContentViewRequest.objects.get(pk=pk)
 
-#             #Prevent non-admin users from deleting posts from other users
-#             requesting_user = WhoYouUser.objects.get(user=request.auth.user)
-#             if requesting_user == content.owner:
-#                 content.delete()
-#                 return Response({}, status=status.HTTP_204_NO_CONTENT)
-#             else:
-#                 return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
+
+            #Prevent users from deleting posts from other users
+            requesting_user = WhoYouUser.objects.get(user=request.auth.user)
+            if requesting_user == contentViewRequest.requester:
+                contentViewRequest.delete()
+                return Response({}, status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
                 
-#         except Content.DoesNotExist as ex:
-#             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-    
-
-# def censorContent(content_object, requestingUser):
-#     isRequesterContentOwner = requestingUser == content_object.owner
-#     if content_object.is_public or isRequesterContentOwner:
-#     #TODO: check if the requester has a valid view request for this content
-#         return content_object
-#     else:
-#         content_object.value = "restricted value"
-#         return content_object
-
-
+        except contentViewRequest.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 class ContentSerializerNoValue(serializers.ModelSerializer):
     """ Serializer for Content that """
     class Meta:

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -28,7 +28,7 @@ class ContentViewRequestViewSet(ViewSet):
 
         content_view_request.save()
 
-        serializer = ContentSerializer(content_view_request, context={'request': request})
+        serializer = ContentViewRequestSerializer(content_view_request, context={'request': request})
         return Response(serializer.data)
 
 #     def list(self, request):
@@ -128,15 +128,17 @@ class ContentViewRequestViewSet(ViewSet):
 #         return content_object
 
 
-class ContentSerializer(serializers.ModelSerializer):
+class ContentSerializerNoValue(serializers.ModelSerializer):
     """ Serializer for Content that """
     class Meta:
         model = Content
+        # Content Value is NOT included to prevent exposing data
         fields = ('id',)
 
 class ContentViewRequestSerializer(serializers.ModelSerializer):
-    """Serializer for Content_View_Requests""" 
-    content = ContentSerializer
+    """Serializer for Content_View_Requests"""
+    # A custom serializer is used to prevent exposing the content value
+    content = ContentSerializerNoValue(many=False)
 
     class Meta:
         model = ContentViewRequest

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -47,23 +47,24 @@ class ContentViewRequestViewSet(ViewSet):
         request_author = WhoYouUser.objects.get(user=request.auth.user)
         filteredRequests = ContentViewRequest.objects.filter(Q(content__owner=request_author) | Q(requester=request_author))
 
-        # TODO: also return requests that are authored by the requester
-
         serializer = ContentViewRequestSerializer(
             filteredRequests, many=True, context={'request': request}
         )
         return Response(serializer.data)
 
 
-#     def retrieve(self, request, pk=None):
-#         """Handle GET request for single content instance
-#         Returns:
-#             Response JSON serialized content instance
-#         """
-#         content = Content.objects.get(pk=pk)
-#         censoredContent = censorContent(content, request.auth.user)
-#         serializer = ContentSerializer(censoredContent, context={'request': request})
-#         return Response(serializer.data)
+    def retrieve(self, request, pk=None):
+        """Handle GET request for single contentViewRequest instance
+        Returns:
+            Response JSON serialized contentViewRequest instance
+        """
+        requester = WhoYouUser.objects.get(user=request.auth.user)
+        contentViewRequest = ContentViewRequest.objects.get(pk=pk)
+        if requester == contentViewRequest.requester or requester == contentViewRequest.content.owner:    
+            serializer = ContentViewRequestSerializer(contentViewRequest, context={'request': request})
+            return Response(serializer.data)
+        else:
+            return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
         
 #     def update(self, request, pk=None):
 #         """ Handle an PUT request for content

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -36,34 +36,21 @@ class ContentViewRequestViewSet(ViewSet):
             serializer = ContentViewRequestSerializer(content_view_request, context={'request': request})
             return Response(serializer.data)
 
-    # def list(self, request):
-    #     """Handle GET requests to Content resource
+    def list(self, request):
+        """Handle GET requests to contentViewRequest resource
 
-    #     Returns:
-    #         Response -- JSON serialized list of Content
-    #     """
-    #     content_objects = Content.objects.all()
-
-    #     # Filter content based on query parameters
-    #     # e.g.: /content?owner=1
-    #     user_id = self.request.query_params.get('owner', None)
-    #     if user_id is not None:
-    #         content_objects = content_objects.filter(owner=user_id)
+        Returns:
+            Response -- JSON serialized list of content view requests
+        """
         
-    #     # Censor out values that the user shouldn't be able to access
-    #     censored_content_objects = []
-    #     for content_object in content_objects:
-    #         try: 
-    #             requester = WhoYouUser.objects.get(user=request.auth.user)
-    #         except AttributeError:
-    #             requester = None
-    #         censored_content = censorContent(content_object, requester)
-    #         censored_content_objects.append(censored_content)
+        requester = WhoYouUser.objects.get(user=request.auth.user)
+        filteredRequests = ContentViewRequest.objects.filter(content__owner=requester)
+        # TODO: also return requests that are authored by the requester
 
-    #     serializer = ContentSerializer(
-    #         censored_content_objects, many=True, context={'request': request}
-    #     )
-    #     return Response(serializer.data)
+        serializer = ContentViewRequestSerializer(
+            filteredRequests, many=True, context={'request': request}
+        )
+        return Response(serializer.data)
 
 
 #     def retrieve(self, request, pk=None):

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -1,0 +1,144 @@
+""" View module for handling requests about content"""
+from whoYouApi.models import content, field_type
+from whoYouApi.models.field_type import FieldType
+from rest_framework.viewsets import ViewSet
+from whoYouApi.models import WhoYouUser, ContentViewRequest, Content
+from django.utils import timezone
+from rest_framework import serializers
+from rest_framework.response import Response
+from rest_framework import status
+
+
+class ContentViewRequestViewSet(ViewSet):
+    """ WhoYou Content """
+
+    def create(self, request):
+        """Handle POST operations
+        Returns:
+            Response -- JSON serialized ContentViewRequest instance
+        """
+        content_view_request = ContentViewRequest()
+        requester = WhoYouUser.objects.get(user=request.auth.user)
+        content_view_request.requester = requester
+        requested_content = request.data["content"]
+        content = Content.objects.get(pk=requested_content)
+        content_view_request.content = content
+        content_view_request.is_approved = False
+        content_view_request.creation_time = timezone.now()
+
+        content_view_request.save()
+
+        serializer = ContentSerializer(content_view_request, context={'request': request})
+        return Response(serializer.data)
+
+#     def list(self, request):
+#         """Handle GET requests to Content resource
+
+#         Returns:
+#             Response -- JSON serialized list of Content
+#         """
+#         content_objects = Content.objects.all()
+
+#         # Filter content based on query parameters
+#         # e.g.: /content?owner=1
+#         user_id = self.request.query_params.get('owner', None)
+#         if user_id is not None:
+#             content_objects = content_objects.filter(owner=user_id)
+        
+#         # Censor out values that the user shouldn't be able to access
+#         censored_content_objects = []
+#         for content_object in content_objects:
+#             try: 
+#                 requester = WhoYouUser.objects.get(user=request.auth.user)
+#             except AttributeError:
+#                 requester = None
+#             censored_content = censorContent(content_object, requester)
+#             censored_content_objects.append(censored_content)
+
+#         serializer = ContentSerializer(
+#             censored_content_objects, many=True, context={'request': request}
+#         )
+#         return Response(serializer.data)
+
+
+#     def retrieve(self, request, pk=None):
+#         """Handle GET request for single content instance
+#         Returns:
+#             Response JSON serialized content instance
+#         """
+#         content = Content.objects.get(pk=pk)
+#         censoredContent = censorContent(content, request.auth.user)
+#         serializer = ContentSerializer(censoredContent, context={'request': request})
+#         return Response(serializer.data)
+        
+#     def update(self, request, pk=None):
+#         """ Handle an PUT request for content
+#         Returns:
+#             Response code
+#         """
+
+#         # Find the post being updated based on it's primary key
+#         content = Content.objects.get(pk=pk)
+
+#         #Prevent non-admin users from modifying other user's posts
+#         requester = WhoYouUser.objects.get(user=request.auth.user)
+#         if requester != content.owner:
+#             return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
+
+#         # save basic (non-associated) properties
+#         content.owner = requester
+#         field_type = FieldType.objects.get(pk=request.data["field_type"])
+#         content.field_type = field_type
+#         content.value = request.data["value"]
+#         content.is_public = request.data["is_public"] == "true"
+#         content.verification_time = timezone.now()
+
+#         # save content object
+#         content.save()
+
+#         return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+#     def destroy(self, request, pk=None):
+#         """ Handle an DELETE request for content
+#         Returns:
+#             Response code
+#         """
+#         try:
+#             content = Content.objects.get(pk=pk)
+
+#             #Prevent non-admin users from deleting posts from other users
+#             requesting_user = WhoYouUser.objects.get(user=request.auth.user)
+#             if requesting_user == content.owner:
+#                 content.delete()
+#                 return Response({}, status=status.HTTP_204_NO_CONTENT)
+#             else:
+#                 return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
+                
+#         except Content.DoesNotExist as ex:
+#             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+    
+
+# def censorContent(content_object, requestingUser):
+#     isRequesterContentOwner = requestingUser == content_object.owner
+#     if content_object.is_public or isRequesterContentOwner:
+#     #TODO: check if the requester has a valid view request for this content
+#         return content_object
+#     else:
+#         content_object.value = "restricted value"
+#         return content_object
+
+
+class ContentSerializer(serializers.ModelSerializer):
+    """ Serializer for Content that """
+    class Meta:
+        model = Content
+        fields = ('id',)
+
+class ContentViewRequestSerializer(serializers.ModelSerializer):
+    """Serializer for Content_View_Requests""" 
+    content = ContentSerializer
+
+    class Meta:
+        model = ContentViewRequest
+        fields = ( 'id', 'requester', 'content', 'is_approved', 'creation_time')
+        depth = 1

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework import status
+from django.db.models import Q    
 
 
 class ContentViewRequestViewSet(ViewSet):
@@ -43,8 +44,9 @@ class ContentViewRequestViewSet(ViewSet):
             Response -- JSON serialized list of content view requests
         """
         
-        requester = WhoYouUser.objects.get(user=request.auth.user)
-        filteredRequests = ContentViewRequest.objects.filter(content__owner=requester)
+        request_author = WhoYouUser.objects.get(user=request.auth.user)
+        filteredRequests = ContentViewRequest.objects.filter(Q(content__owner=request_author) | Q(requester=request_author))
+
         # TODO: also return requests that are authored by the requester
 
         serializer = ContentViewRequestSerializer(

--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -66,32 +66,25 @@ class ContentViewRequestViewSet(ViewSet):
         else:
             return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
         
-#     def update(self, request, pk=None):
-#         """ Handle an PUT request for content
-#         Returns:
-#             Response code
-#         """
+    def partial_update(self, request, pk=None):
+        """ Handle an PATCH request for single contentViewRequest
+        Returns:
+            Response code
+        """
 
-#         # Find the post being updated based on it's primary key
-#         content = Content.objects.get(pk=pk)
+        # Find the post being updated based on it's primary key
+        contentViewRequest = ContentViewRequest.objects.get(pk=pk)
 
-#         #Prevent non-admin users from modifying other user's posts
-#         requester = WhoYouUser.objects.get(user=request.auth.user)
-#         if requester != content.owner:
-#             return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
+        #Prevent non-admin users from modifying other user's posts
+        requester = WhoYouUser.objects.get(user=request.auth.user)
+        if requester != contentViewRequest.content.owner:
+            return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
 
-#         # save basic (non-associated) properties
-#         content.owner = requester
-#         field_type = FieldType.objects.get(pk=request.data["field_type"])
-#         content.field_type = field_type
-#         content.value = request.data["value"]
-#         content.is_public = request.data["is_public"] == "true"
-#         content.verification_time = timezone.now()
+        contentViewRequest.is_approved = request.data["is_approved"]
 
-#         # save content object
-#         content.save()
+        contentViewRequest.save()
 
-#         return Response({}, status=status.HTTP_204_NO_CONTENT)
+        return Response({}, status=status.HTTP_204_NO_CONTENT)
 
 #     def destroy(self, request, pk=None):
 #         """ Handle an DELETE request for content

--- a/whoYouServer/urls.py
+++ b/whoYouServer/urls.py
@@ -1,12 +1,13 @@
 from django.conf.urls import include
 from django.urls import path
 from rest_framework import routers
-from whoYouApi.views import register_user, login_user, ContentViewSet
+from whoYouApi.views import register_user, login_user, ContentViewSet, ContentViewRequestViewSet
 
 
 """Router"""
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'content', ContentViewSet, 'content')
+router.register(r'contentViewRequest', ContentViewRequestViewSet, 'contentViewRequest')
 
 urlpatterns = [
     path('', include(router.urls)),


### PR DESCRIPTION
# Description
Add a Content_View_Request viewset. This allows users to create requests to view other user's content, and for content owners to modify those requests with approvals. Tests were added to make sure that only correctly authenticated users can access the values of content fields.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Review `tests/contentViewRequest_tests.py` for test coverage and accuracy
- [ ] Run the tests: 'python manage.py test tests -v 1`
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings