### PR TITLE
Add access to approved view requests

### DIFF
--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -45,7 +45,7 @@ class ContentTests(APITestCase):
         self.agentSmithToken = smithResponse["token"]
         
 
-    def test_request_content_as_unauthenticated(self):
+    def test_get_content_as_unauthenticated_expect_restriced_unless_public(self):
         """
         Verify that the correct values are returned when an un-authenticated user GETs a user's content
         """
@@ -63,7 +63,7 @@ class ContentTests(APITestCase):
                 self.assertEqual(content["value"], "restricted value")
     
 
-    def test_request_content_as_self(self):
+    def test_get_content_as_owner_expect_unrestricted(self):
         """
         Verify that the correct values are returned when user GETs their own content
         """
@@ -85,7 +85,7 @@ class ContentTests(APITestCase):
                 self.assertEqual(content["value"], "trinity@theResistance.com")
 
 
-    def test_request_content_as_other(self):
+    def test_get_content_as_other_expect_restriced_unless_public(self):
         """
         Verify that the correct values are returned when user GETs another user's content
         """
@@ -105,6 +105,13 @@ class ContentTests(APITestCase):
                 self.assertEqual(content["value"], "restricted value")
             if content["field_type"]["name"] == "email":
                 self.assertEqual(content["value"], "restricted value")
+
+    def test_get_content_as_approved_other_expect_unrestricted(self):
+        """
+        When a user has an approved content_view_request, they should 
+        be able to access content that isn't public
+        """
+        
         
 
 # TODO Add tests for retrieving a specific piece of content by id

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -43,6 +43,19 @@ class ContentTests(APITestCase):
         smithResponse = createUser(agentSmithData)
         self.agentSmithId = smithResponse["id"]
         self.agentSmithToken = smithResponse["token"]
+
+        # Post a request to view trinity's content as smith
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        data = {
+           "content": 2
+        }
+        url = "/contentViewRequest"
+        response = client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.agentSmithRequestForTrinityInfo = json_response["id"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["is_approved"], False)
         
 
     def test_get_content_as_unauthenticated_expect_restriced_unless_public(self):
@@ -112,18 +125,7 @@ class ContentTests(APITestCase):
         be able to access content that isn't public
         """
         client = APIClient()
-
-        # Post a request to view trinity's content as smith
         client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
-        data = {
-           "content": 2
-        }
-        url = "/contentViewRequest"
-        response = client.post(url, data, format='json')
-        json_response = json.loads(response.content)
-        self.agentSmithRequestForTrinityInfo = json_response["id"]
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
         url = "/content/2"
         response = client.get(url, format='json')
         json_response = json.loads(response.content)
@@ -136,19 +138,7 @@ class ContentTests(APITestCase):
         be able to access content that isn't public
         """
         client = APIClient()
-
-        # Post a request to view trinity's content as smith
-        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
-        data = {
-           "content": 2
-        }
-        url = "/contentViewRequest"
-        response = client.post(url, data, format='json')
-        json_response = json.loads(response.content)
-        self.agentSmithRequestForTrinityInfo = json_response["id"]
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # Approve smith's request as trinity
+        # Approve smith's request to view trinity's content
         url = F"/contentViewRequest/{self.agentSmithRequestForTrinityInfo}"
         client.credentials(HTTP_AUTHORIZATION='Token ' + self.trinityToken)
         data = {
@@ -157,6 +147,8 @@ class ContentTests(APITestCase):
         response = client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+        # authenticate as smith, and read the phone number MUAHH HA HA!
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
         url = "/content/2"
         response = client.get(url, format='json')
         json_response = json.loads(response.content)

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -106,6 +106,30 @@ class ContentTests(APITestCase):
             if content["field_type"]["name"] == "email":
                 self.assertEqual(content["value"], "restricted value")
 
+    def test_get_content_as_unapproved_other_expect_restricted(self):
+        """
+        When a user has an UNapproved content_view_request, they should NOT
+        be able to access content that isn't public
+        """
+        client = APIClient()
+
+        # Post a request to view trinity's content as smith
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        data = {
+           "content": 2
+        }
+        url = "/contentViewRequest"
+        response = client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.agentSmithRequestForTrinityInfo = json_response["id"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        url = "/content/2"
+        response = client.get(url, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["value"], "restricted value")
+
     def test_get_content_as_approved_other_expect_unrestricted(self):
         """
         When a user has an approved content_view_request, they should 
@@ -138,8 +162,6 @@ class ContentTests(APITestCase):
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["value"], "1234567890")
-
-
 
         
 

--- a/tests/content_tests.py
+++ b/tests/content_tests.py
@@ -111,7 +111,36 @@ class ContentTests(APITestCase):
         When a user has an approved content_view_request, they should 
         be able to access content that isn't public
         """
-        
+        client = APIClient()
+
+        # Post a request to view trinity's content as smith
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.agentSmithToken)
+        data = {
+           "content": 2
+        }
+        url = "/contentViewRequest"
+        response = client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+        self.agentSmithRequestForTrinityInfo = json_response["id"]
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Approve smith's request as trinity
+        url = F"/contentViewRequest/{self.agentSmithRequestForTrinityInfo}"
+        client.credentials(HTTP_AUTHORIZATION='Token ' + self.trinityToken)
+        data = {
+           "is_approved": True
+        }
+        response = client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        url = "/content/2"
+        response = client.get(url, format='json')
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["value"], "1234567890")
+
+
+
         
 
 # TODO Add tests for retrieving a specific piece of content by id


### PR DESCRIPTION
# Description
The whole point of users creating requests to view content, and approve those requests was to allow those approved users to view that content. Here it is! 
## Type of change
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Review the tests for coverage and accuracy
- [ ] Run `python manage.py test tests -v 1`
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings