### PR TITLE
fix content view request delete exeption

### DIFF
--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -100,7 +100,7 @@ class ContentViewRequestViewSet(ViewSet):
             else:
                 return Response({"message": "Permission denied"}, status=status.HTTP_401_UNAUTHORIZED)
                 
-        except contentViewRequest.DoesNotExist as ex:
+        except ContentViewRequest.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 class ContentSerializerNoValue(serializers.ModelSerializer):
     """ Serializer for Content that """


### PR DESCRIPTION
# Description
When attempting to delete a contentViewRequest that didn't exist in the database, an error saying that `contentViewRequest` was accessed before it was defined was thrown. This error was traced to line 103, which was intended to throw an exception with a 404 message. This line was then fixed so that it would properly refer to the model instead of the instance, so that the error will be thrown.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Verfied that after this change, the proper exception is thrown.
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings