### PR TITLE
add user name to content view request data

### DIFF
--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -108,11 +108,20 @@ class ContentSerializerNoValue(serializers.ModelSerializer):
         model = Content
         # Content Value is NOT included to prevent exposing data
         fields = ('id',)
+        
+class WhoYouUserSerializer(serializers.ModelSerializer):
+    """Serializer for WhoYouUsers""" 
+
+    class Meta:
+        model = WhoYouUser
+        fields = ( 'id', 'profile_image_path', 'cover_image_path', 'name')
+        depth = 1
 
 class ContentViewRequestSerializer(serializers.ModelSerializer):
     """Serializer for Content_View_Requests"""
     # A custom serializer is used to prevent exposing the content value
     content = ContentSerializerNoValue(many=False)
+    requester = WhoYouUserSerializer(many=False)
 
     class Meta:
         model = ContentViewRequest


### PR DESCRIPTION
# Description
In building the client manager for content view requests it became apparent that the user name was needed as part of this data. This change exposes the user name in the response.
## Type of change
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] In postman, GET `http://localhost:8000/contentViewRequest`, and verify that each requester's name is included in the response
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings