### PR TITLE
add field type to list of content view request for use in the client

### DIFF
--- a/whoYouApi/views/content_view_request.py
+++ b/whoYouApi/views/content_view_request.py
@@ -107,7 +107,8 @@ class ContentSerializerNoValue(serializers.ModelSerializer):
     class Meta:
         model = Content
         # Content Value is NOT included to prevent exposing data
-        fields = ('id',)
+        fields = ('id', 'field_type')
+        depth = 2
         
 class WhoYouUserSerializer(serializers.ModelSerializer):
     """Serializer for WhoYouUsers""" 


### PR DESCRIPTION
# Description
For displaying notifications of contentViewRequests in the client, it is useful to the name of the type of field that is being requested. This change adds that data to the response to a get request.
## Type of change
- [ ] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] In postman, GET `http://localhost:8000/contentViewRequest`, and verify that the field-type and name of the field type are included in the response
- [ ] Also, verify that the tests still pass
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings