### PR TITLE
fix saving and updating of is_public value

### DIFF
--- a/whoYouApi/views/content.py
+++ b/whoYouApi/views/content.py
@@ -23,7 +23,7 @@ class ContentViewSet(ViewSet):
         field_type = FieldType.objects.get(pk=request.data["field_type"])
         content.field_type = field_type
         content.value = request.data["value"]
-        content.is_public = request.data["is_public"] == "true"
+        content.is_public = request.data["is_public"]
         content.verification_time = timezone.now()
 
         serializer = ContentSerializer(content, context={'request': request})
@@ -86,7 +86,7 @@ class ContentViewSet(ViewSet):
         field_type = FieldType.objects.get(pk=request.data["field_type"])
         content.field_type = field_type
         content.value = request.data["value"]
-        content.is_public = request.data["is_public"] == "true"
+        content.is_public = request.data["is_public"]
         content.verification_time = timezone.now()
 
         content.save()


### PR DESCRIPTION
# Description
When updating content sharing settings, a bug was found where all content was set to is_public False. This was due to the back end dev (me) being too smart for his own good, and trying to interpret a bool as a string, even though django automatically translates it to a bool when it converts from json.
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?
Please describe step-by-step the process that a reviewer can follow to adequately test this PR. 
- [ ] Verify that content can be saved as public
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings